### PR TITLE
Use OpenJDK development version instead of runtime only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN set -xe \
 ENV SCALA_VERSION=2.12.1
 ENV SCALA_URL=http://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz
 RUN set -xe \
-    && dnf --assumeyes install java-1.8.0-openjdk \
+    && dnf --assumeyes install java-1.8.0-openjdk-devel \
     && dnf clean all \
     && mkdir -p /tmp/scala \
     && cd /tmp/scala \


### PR DESCRIPTION
When building the Vamp docker files from scratch on my Mac I run into the issue that it failed with this error:
```
java.io.FileNotFoundException: Could not automatically find the JDK/lib/tools.jar.
You must explicitly set JDK_HOME or JAVA_HOME.
```

When I looked into the `magneticio/buildserver` I noticed that only the JRE exists and not JDK.